### PR TITLE
Fix Advanced Duplicator 2 compactability

### DIFF
--- a/lua/entities/prop_door_dynamic.lua
+++ b/lua/entities/prop_door_dynamic.lua
@@ -17,6 +17,7 @@ function ENT:Initialize()
 
 	if ( SERVER ) then
 		self:PhysicsInitStatic( SOLID_VPHYSICS )
+		self:SetSolid( SOLID_NONE )
 		self:CreateBoneFollowers()
 	end
 

--- a/lua/entities/prop_door_dynamic.lua
+++ b/lua/entities/prop_door_dynamic.lua
@@ -16,6 +16,7 @@ function ENT:Initialize()
 	-- self:PhysicsInit( SOLID_VPHYSICS )
 
 	if ( SERVER ) then
+		self:PhysicsInitStatic( SOLID_VPHYSICS )
 		self:CreateBoneFollowers()
 	end
 


### PR DESCRIPTION
The only thing that makes it not work with doors is an invalid physical object.